### PR TITLE
Fixing broken build due to incomplete lineage.dependencies

### DIFF
--- a/lineage.dependencies
+++ b/lineage.dependencies
@@ -6,5 +6,13 @@
   {
     "repository": "android_kernel_sony_sm8550",
     "target_path": "kernel/sony/sm8550"
+  },
+  {
+    "repository": "android_kernel_sony_sm8550-devicetrees",
+    "target_path": "kernel/sony/sm8550-devicetrees"
+  },
+  {
+    "repository": "android_kernel_sony_sm8550-modules",
+    "target_path": "kernel/sony/sm8550-modules"
   }
 ]


### PR DESCRIPTION
The lineage.dependencies file was missing a reference to the devicetrees and modules repos, and it was making any attempts to build fail due to missing qualcomm display drivers